### PR TITLE
use run instead of shell

### DIFF
--- a/lib/Git/Simple.pm
+++ b/lib/Git/Simple.pm
@@ -6,7 +6,7 @@ class Git::Simple {
     has Str $.cwd = '.';
 
     method branch-info {
-        my $proc = shell "git -C $.cwd status --porcelain -b", :out;
+        my $proc = run <git -C>, $.cwd, <status --porcelain -b>, :out;
         Git::Simple::Parse.new.status(out => $proc.out.slurp-rest.Str.lines[0]);
     }
 


### PR DESCRIPTION
It is better to use `run` because then you don't have to worry about escaping metacharacters and spaces in the directory name.