### PR TITLE
Use SPDX identifier in license field of META6.json

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -1,5 +1,6 @@
 {
     "name"          : "Git::Simple",
+    "license"       : "MIT",
     "version"       : "0.0.2",
     "perl"          : "6",
     "description"   : "Simple interface to Git command",


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license